### PR TITLE
add a plugin that is not accessible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,13 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v3
-    - name: Setup SSH Git Auth
-      run: |
-         eval "$(ssh-agent -s)"
-         ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+#      - name: Setup SSH Git Auth
+#        run: |
+#          eval "$(ssh-agent -s)"
+#          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+    - uses: de-vri-es/setup-git-credentials@v2
+      with:
+        credentials: ${{secrets.GIT_CREDENTIALS}}
     - uses: coursier/setup-action@v1.2.0-M3
       with:
         jvm: ${{ matrix.jvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 #      - uses: de-vri-es/setup-git-credentials@v2
 #        with:
 #          credentials: ${{secrets.GIT_CREDENTIALS}}
-      - name: Configure git
-        env:
-          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
-        run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
+#      - name: Configure git
+#        env:
+#          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
+#        run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
       - uses: coursier/setup-action@v1.2.0-M3
         with:
           apps: scalafmt sbt
@@ -56,10 +56,10 @@ jobs:
 #    - uses: de-vri-es/setup-git-credentials@v2
 #      with:
 #        credentials: ${{secrets.GIT_CREDENTIALS}}
-    - name: Configure git
-      env:
-          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
-      run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
+#    - name: Configure git
+#      env:
+#          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
+#      run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
     - uses: coursier/setup-action@v1.2.0-M3
       with:
         jvm: ${{ matrix.jvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Git Auth
         run: |
           eval "$(ssh-agent -s)"
-          ssh-add - <<< ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
           
       - uses: coursier/setup-action@v1.2.0-M3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,13 @@ jobs:
         working-directory: sbt-plugin
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Git Auth
-        run: |
-          eval "$(ssh-agent -s)"
-          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
-          
+#      - name: Setup SSH Git Auth
+#        run: |
+#          eval "$(ssh-agent -s)"
+#          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
+      - uses: de-vri-es/setup-git-credentials@v2
+        with:
+          credentials: ${{secrets.GIT_CREDENTIALS}}
       - uses: coursier/setup-action@v1.2.0-M3
         with:
           apps: scalafmt sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
     - uses: actions/checkout@v3
+    - name: Setup SSH Git Auth
+      run: |
+         eval "$(ssh-agent -s)"
+         ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
     - uses: coursier/setup-action@v1.2.0-M3
       with:
         jvm: ${{ matrix.jvm }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         working-directory: sbt-plugin
     steps:
       - uses: actions/checkout@v3
+      - name: Setup Git Auth
+        run: |
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< ${{ secrets.SSH_PRIVATE_KEY }}
+          
       - uses: coursier/setup-action@v1.2.0-M3
         with:
           apps: scalafmt sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,13 @@ jobs:
 #        run: |
 #          eval "$(ssh-agent -s)"
 #          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
-      - uses: de-vri-es/setup-git-credentials@v2
-        with:
-          credentials: ${{secrets.GIT_CREDENTIALS}}
+#      - uses: de-vri-es/setup-git-credentials@v2
+#        with:
+#          credentials: ${{secrets.GIT_CREDENTIALS}}
+      - name: Configure git
+        env:
+          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
+        run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
       - uses: coursier/setup-action@v1.2.0-M3
         with:
           apps: scalafmt sbt
@@ -49,9 +53,13 @@ jobs:
 #        run: |
 #          eval "$(ssh-agent -s)"
 #          ssh-add - <<< "${{ secrets.SSH_PRIVATE_KEY }}"
-    - uses: de-vri-es/setup-git-credentials@v2
-      with:
-        credentials: ${{secrets.GIT_CREDENTIALS}}
+#    - uses: de-vri-es/setup-git-credentials@v2
+#      with:
+#        credentials: ${{secrets.GIT_CREDENTIALS}}
+    - name: Configure git
+      env:
+          TOKEN: ${{ secrets.GIT_CREDENTIALS }}
+      run: git config --global url."https://${TOKEN}:[x-oauth-basic@github.com](mailto:x-oauth-basic@github.com)/".insteadOf "https://github.com/"
     - uses: coursier/setup-action@v1.2.0-M3
       with:
         jvm: ${{ matrix.jvm }}

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("ssh://github.com/testing-felickz/private-repo.git")))
+  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo")))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("git://github.com/testing-felickz/private-repo")))
+  dependsOn(RootProject(uri("ssh://github.com/testing-felickz/private-repo.git")))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo.git")))
+  dependsOn(RootProject(uri("git://github.com/testing-felickz/private-repo")))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("https://github.com/felickz/does-not-exist#v0.0.1)))
+  dependsOn(RootProject(uri("https://github.com/felickz/does-not-exist#v0.0.1")))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -54,3 +54,5 @@ val `sbt-github-dependency-submission` = project
       publishLocal.value
     }
   )
+  
+  dependsOn(RootProject(uri("https://github.com/felickz/does-not-exist#v0.0.1)))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo#v0.0.1")))
+  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo.git")))

--- a/sbt-plugin/build.sbt
+++ b/sbt-plugin/build.sbt
@@ -55,4 +55,4 @@ val `sbt-github-dependency-submission` = project
     }
   )
   
-  dependsOn(RootProject(uri("https://github.com/felickz/does-not-exist#v0.0.1")))
+  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo#v0.0.1")))


### PR DESCRIPTION
# .git reference

[build.sbt](https://github.com/testing-felickz/sbt-dependency-submission/pull/1/commits/64be9dcb3ef960b4a7e0ed3e51205e75372fe011)
```scala
  dependsOn(RootProject(uri("https://github.com/testing-felickz/private-repo.git")))
```


[Failing build ](https://github.com/testing-felickz/sbt-dependency-submission/actions/runs/3493775765/jobs/5848952671#step:4:21)

```
Cloning into '/home/runner/.sbt/1.0/staging/1af161268de0903f9cce/private-repo'...
fatal: could not read Username for 'https://github.com/': No such device or address
java.lang.RuntimeException: Nonzero exit code (128): git clone --depth 1 https://github.com/testing-felickz/private-repo.git /home/runner/.sbt/1.0/staging/1af161268de0903f9cce/private-repo
```

# Configure Git Credentials
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#using-a-token-on-the-command-line
- [Create SSH keypair](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key)
- [Setup deploy keys](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys)